### PR TITLE
Add Zalo OA tag methods

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -3,6 +3,7 @@ from test.test_oa_create_request_body import ZaloSendRequestBody
 from test.test_create_request_header import ZaloSendRequestHeader
 from test.test_get_user_detail import ZaloGetUserDetail
 from test.test_get_zalo_quotas import ZaloGetZaloQuotas
+from test.test_oa_tag_methods import ZaloOATagMethods
 
 def create_test_suite():
     test_suite = unittest.TestSuite()
@@ -10,6 +11,7 @@ def create_test_suite():
     test_suite.addTest(unittest.TestLoader().loadTestsFromTestCase(ZaloSendRequestHeader))
     test_suite.addTest(unittest.TestLoader().loadTestsFromTestCase(ZaloGetUserDetail))
     test_suite.addTest(unittest.TestLoader().loadTestsFromTestCase(ZaloGetZaloQuotas))
+    test_suite.addTest(unittest.TestLoader().loadTestsFromTestCase(ZaloOATagMethods))
 
     return test_suite
 

--- a/test/test_oa_tag_methods.py
+++ b/test/test_oa_tag_methods.py
@@ -1,0 +1,119 @@
+from unittest.mock import Mock
+
+from zalo_sdk.oa.Client import Client
+
+from . import ZaloSendMessage
+
+
+class ZaloOATagMethods(ZaloSendMessage):
+
+    def _create_client(self):
+        return Client(
+            self.app_id,
+            self.secret_key,
+            access_token="access-token",
+            refresh_token=self.refresh_token,
+            endpoint_prefix="https://test.openapi.zalo.me",
+        )
+
+    def _mock_client_response(self, client):
+        raw_response = Mock()
+        validated_response = {
+            "error": 0,
+            "message": "Success",
+        }
+        client.send_request = Mock(return_value=raw_response)
+        client._validate_zalo_response = Mock(return_value=validated_response)
+
+        return raw_response, validated_response
+
+    def test_tag_follower_posts_expected_request(self):
+        client = self._create_client()
+        raw_response, validated_response = self._mock_client_response(client)
+
+        result = client.tag_follower(
+            user_id="2468458835296197922",
+            tag_name="Khach hang mua lan dau",
+        )
+
+        client.send_request.assert_called_once_with(
+            method="POST",
+            url="https://test.openapi.zalo.me/v2.0/oa/tag/tagfollower",
+            body={
+                "user_id": "2468458835296197922",
+                "tag_name": "Khach hang mua lan dau",
+            },
+            headers={
+                "Content-Type": "application/json",
+                "access_token": "access-token",
+            },
+        )
+        client._validate_zalo_response.assert_called_once_with(raw_response)
+        self.assertEqual(result, validated_response)
+
+    def test_rm_follower_from_tag_posts_expected_request(self):
+        client = self._create_client()
+        raw_response, validated_response = self._mock_client_response(client)
+
+        result = client.rm_follower_from_tag(
+            user_id="2468458835296197922",
+            tag_name="Khach hang mua lan dau",
+        )
+
+        client.send_request.assert_called_once_with(
+            method="POST",
+            url="https://test.openapi.zalo.me/v2.0/oa/tag/rmfollowerfromtag",
+            body={
+                "user_id": "2468458835296197922",
+                "tag_name": "Khach hang mua lan dau",
+            },
+            headers={
+                "Content-Type": "application/json",
+                "access_token": "access-token",
+            },
+        )
+        client._validate_zalo_response.assert_called_once_with(raw_response)
+        self.assertEqual(result, validated_response)
+
+    def test_get_tags_of_oa_gets_expected_request(self):
+        client = self._create_client()
+        raw_response = Mock()
+        validated_response = {
+            "data": ["Khach Q1", "Khach Q2"],
+            "error": 0,
+            "message": "Success",
+        }
+        client.send_request = Mock(return_value=raw_response)
+        client._validate_zalo_response = Mock(return_value=validated_response)
+
+        result = client.get_tags_of_oa()
+
+        client.send_request.assert_called_once_with(
+            method="GET",
+            url="https://test.openapi.zalo.me/v2.0/oa/tag/gettagsofoa",
+            headers={
+                "access_token": "access-token",
+            },
+        )
+        client._validate_zalo_response.assert_called_once_with(raw_response)
+        self.assertEqual(result, validated_response)
+
+    def test_rm_tag_posts_expected_request(self):
+        client = self._create_client()
+        raw_response, validated_response = self._mock_client_response(client)
+
+        result = client.rm_tag(tag_name="Khach hang mua lan dau")
+
+        client.send_request.assert_called_once_with(
+            method="POST",
+            url="https://test.openapi.zalo.me/v2.0/oa/tag/rmtag",
+            body={
+                "tag_name": "Khach hang mua lan dau",
+            },
+            headers={
+                "Content-Type": "application/json",
+                "access_token": "access-token",
+            },
+        )
+        client._validate_zalo_response.assert_called_once_with(raw_response)
+        self.assertEqual(result, validated_response)

--- a/zalo_sdk/oa/Client.py
+++ b/zalo_sdk/oa/Client.py
@@ -158,6 +158,45 @@ class Client(zalo_sdk.BaseClient):
         )
         return self._validate_zalo_response(response)
 
+    def tag_follower(self, user_id, tag_name):
+        headers = self.create_request_header(method="POST")
+        body = {
+            "user_id": user_id,
+            "tag_name": tag_name,
+        }
+        url = f"{self.endpoint_prefix}/v2.0/oa/tag/tagfollower"
+        response = self.send_request(
+            method="POST", url=url, body=body, headers=headers)
+        return self._validate_zalo_response(response)
+
+    def rm_follower_from_tag(self, user_id, tag_name):
+        headers = self.create_request_header(method="POST")
+        body = {
+            "user_id": user_id,
+            "tag_name": tag_name,
+        }
+        url = f"{self.endpoint_prefix}/v2.0/oa/tag/rmfollowerfromtag"
+        response = self.send_request(
+            method="POST", url=url, body=body, headers=headers)
+        return self._validate_zalo_response(response)
+
+    def get_tags_of_oa(self):
+        headers = self.create_request_header(method="GET")
+        url = f"{self.endpoint_prefix}/v2.0/oa/tag/gettagsofoa"
+        response = self.send_request(
+            method="GET", url=url, headers=headers)
+        return self._validate_zalo_response(response)
+
+    def rm_tag(self, tag_name):
+        headers = self.create_request_header(method="POST")
+        body = {
+            "tag_name": tag_name,
+        }
+        url = f"{self.endpoint_prefix}/v2.0/oa/tag/rmtag"
+        response = self.send_request(
+            method="POST", url=url, body=body, headers=headers)
+        return self._validate_zalo_response(response)
+
     def _validate_zalo_response(self, response):
         self.check_http_error(response)
 


### PR DESCRIPTION
- Add 4 brand news method to handle with Zalo OA tag 
-  [Gắn nhãn người dùng](https://developers.zalo.me/docs/official-account/quan-ly/quan-ly-thong-tin-nguoi-dung/gan-nhan-nguoi-dung)
- [Gỡ nhãn người dùng](https://developers.zalo.me/docs/official-account/quan-ly/quan-ly-thong-tin-nguoi-dung/go-nhan-nguoi-dung)
-  [Lấy danh sách nhãn](https://developers.zalo.me/docs/official-account/quan-ly/quan-ly-thong-tin-nguoi-dung/lay-danh-sach-nhan)
-  [Xóa nhãn](https://developers.zalo.me/docs/official-account/quan-ly/quan-ly-thong-tin-nguoi-dung/xoa-nhan)